### PR TITLE
Add libraries for linker (else undefined references)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ ELSE(APPLE)
    TARGET_LINK_LIBRARIES(pfpd pfp boost_filesystem boost_thread boost_regex boost_system icuio icuuc)
    TARGET_LINK_LIBRARIES(pfpc pfp boost_filesystem boost_thread boost_regex boost_system icuio icuuc)
    TARGET_LINK_LIBRARIES(pfpc_token pfp boost_filesystem boost_thread boost_regex boost_system icuio icuuc)
-   TARGET_LINK_LIBRARIES(test pfp boost_thread boost_unit_test_framework boost_regex icuio icuuc)
+   TARGET_LINK_LIBRARIES(test pfp boost_filesystem boost_thread boost_unit_test_framework boost_regex boost_system icuio icuuc)
 ENDIF(APPLE)
 
 INSTALL(TARGETS pfpd DESTINATION bin)


### PR DESCRIPTION
Without the boost system and filesystem libraries, the linker will fail with undefined references when compiling test. This adds those two libraries to the CMake rule for test.

I believe this shouldn't be specific to any system
(Ubuntu 11.10, 64 bit)

```
/usr/bin/c++       CMakeFiles/test.dir/src/test/lexicon.o CMakeFiles/test.dir/src/test/pcfg_parser.o CMakeFiles/test.dir/src/test/tokenizer.o CMakeFiles/test.dir/src/test/pfp.o CMakeFiles/test.dir/src/test/main.o  -o test -rdynamic libpfp.so -lboost_thread -lboost_unit_test_framework -lboost_regex -licuio -licuuc -Wl,-rpath,/home/smerity/Coding/Reference/pfp
CMakeFiles/test.dir/src/test/pfp.o: In function `pfp_parser_test::test_pfp_hash::test_method()':
pfp.cpp:(.text+0x1b47): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1bac): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1bf0): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x1c1c): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x1d82): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1ddd): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1e18): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x1e44): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x1ebf): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1f1a): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1f5d): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x1f9e): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x1ff9): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2034): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x206e): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x20c9): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2104): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x213e): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2199): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x21d4): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x2548): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x289a): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x290e): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x2982): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x2a7c): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2ad7): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2b12): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x2b3e): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
pfp.cpp:(.text+0x2bb9): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2c14): undefined reference to `boost::filesystem3::path::wchar_t_codecvt_facet()'
pfp.cpp:(.text+0x2c4f): undefined reference to `boost::filesystem3::path::operator/=(boost::filesystem3::path const&)'
pfp.cpp:(.text+0x2c7b): undefined reference to `boost::filesystem3::detail::status(boost::filesystem3::path const&, boost::system::error_code*)'
CMakeFiles/test.dir/src/test/pfp.o: In function `_GLOBAL__sub_I__ZN15pfp_parser_test13test_pfp_hash11test_methodEv':
pfp.cpp:(.text.startup+0x3f): undefined reference to `boost::system::generic_category()'
pfp.cpp:(.text.startup+0x4b): undefined reference to `boost::system::generic_category()'
pfp.cpp:(.text.startup+0x57): undefined reference to `boost::system::system_category()'
collect2: ld returned 1 exit status
```
